### PR TITLE
Use uniforms for gradient placement

### DIFF
--- a/shaders/gradient.frag
+++ b/shaders/gradient.frag
@@ -1,9 +1,14 @@
 #version 330
 
-in vec4 outColor;
+in vec2 uv;
 out vec4 outputColor;
+
+uniform vec4 gradientColorStart;
+uniform vec4 gradientColorEnd;
+uniform int gradientHorizontal;
 
 void main()
 {
-    outputColor = outColor;
+    float t = gradientHorizontal == 1 ? uv.x : uv.y;
+    outputColor = mix(gradientColorStart, gradientColorEnd, t);
 }

--- a/shaders/gradient.vert
+++ b/shaders/gradient.vert
@@ -1,12 +1,15 @@
 #version 330
 
-layout(location = 0) in vec4 position;
-layout(location = 1) in vec4 color;
+layout(location = 0) in vec2 position;
 
-out vec4 outColor;
+out vec2 uv;
+
+uniform vec2 gradientPos;
+uniform vec2 gradientSize;
 
 void main()
 {
-    gl_Position = position;
-    outColor = color;
+    uv = position;
+    vec2 scaled = gradientPos + position * gradientSize;
+    gl_Position = vec4(scaled, 0.0, 1.0);
 }


### PR DESCRIPTION
## Summary
- draw gradients from a static unit quad
- add uniforms for gradient translation, size, color and orientation
- update shader code to use the uniforms
- avoid rebuffering when gradient size hasn't changed

## Testing
- `make` *(fails: SDL2 and other dependencies missing)*